### PR TITLE
Fix absolute import

### DIFF
--- a/i2a/i2a.py
+++ b/i2a/i2a.py
@@ -24,9 +24,10 @@ Options:
 """
 
 from __future__ import print_function
+from __future__ import absolute_import
 from setuptools import setup, find_packages
 import subprocess
-from colors import *
+from i2a.colors import *
 from PIL import Image, ImageEnhance
 from docopt import docopt
 


### PR DESCRIPTION
```
~$ python -V
Python 3.5.3
~$ python -m pip install i2a
~$ i2a 
Traceback (most recent call last):
  File "/home/kosh/.local/bin/i2a", line 6, in <module>
    from i2a.i2a import main
  File "/home/kosh/.local/lib/python3.5/site-packages/i2a/i2a.py", line 29, in <module>
    from colors import *
ImportError: No module named 'colors'
```

This patch works python 2/3 compatible.