### PR TITLE
Remove useless import

### DIFF
--- a/i2a/i2a.py
+++ b/i2a/i2a.py
@@ -25,7 +25,6 @@ Options:
 
 from __future__ import print_function
 from __future__ import absolute_import
-from setuptools import setup, find_packages
 import subprocess
 from i2a.colors import *
 from PIL import Image, ImageEnhance


### PR DESCRIPTION
Imported functions `from setuptools import setup, find_packages` is not used in `i2a/i2a.py`. So I remove it.